### PR TITLE
Add "nexus-staging:rc-release" as a command.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.data.build</groupId>
 	<artifactId>spring-data-release-cli</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.BUILD-rc-release-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/readme.adoc
+++ b/readme.adoc
@@ -57,10 +57,8 @@ A job should have started. Click on the active job, and then click on *Open Blue
 
 |===
 
-* For a Maven central release, go to https://s01.oss.sonatype.org/ and login.
-** After logging in, you will find a closed Spring Data Release repository.
-** Click the repository and then choose "Release".
-* For an artifactory release, the release will already have been staged and promoted, so there is nothing more to do.
+* For a Maven central release, if the smoke test has passed, the repository will already have been released, so there is nothing more to do.
+* For an Artifactory release, if the smoke test has passed, the release will already have been staged and promoted, so there is nothing more to do.
 * 🚥 Continue with `Post-release tasks`
 
 [[post-release]]
@@ -100,7 +98,6 @@ Congratulations 🥳 You completed the release ❤️.
 ===== Infrastructure requirements
 
 * Ensure you have the credentials for `buildmaster` accounts on https://repo.spring.io.
-* Ensure you have the credentials for https://oss.sonatype.org (to deploy and promote GA and service releases, need deployment permissions for `org.springframework.data`) in `settings.xml` for server with id `sonatype`.
 
 Both are available in the Spring/Pivotal Last Pass repository.
 
@@ -139,7 +136,7 @@ See `application-local.template` for details.
 | |`$ release prepare $trainIteration`
 | |`$ release conclude $trainIteration`
 2+| *Build the release*
-|Build the artifacts from tag and push them to the appropriate maven repository |`$ release build $trainIteration`
+|Build the artifacts from tag and push them to the appropriate maven repository. Also runs smoke tests, does Sonatype "release" if applicable, and does Artifactory "promote" if applicable. |`$ release build $trainIteration`
 |Distribute documentation and static resources from tag |`$ release distribute $trainIteration`
 |Push the created commits to GitHub |`$ github push $trainIteration`
 |Push new maintenance branches if the release version was a GA release (`X.Y.0` version) |`$ git push $trainIteration.next`

--- a/src/main/java/org/springframework/data/release/build/BuildSystem.java
+++ b/src/main/java/org/springframework/data/release/build/BuildSystem.java
@@ -30,6 +30,7 @@ import org.springframework.plugin.core.Plugin;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Greg Turnquist
  */
 interface BuildSystem extends Plugin<Project> {
 
@@ -67,6 +68,11 @@ interface BuildSystem extends Plugin<Project> {
 	 * Close a remote repository for staging artifacts.
 	 */
 	void close(StagingRepository stagingRepository);
+
+	/**
+	 * Release a remote repository of staged artifacts.
+	 */
+	void release(StagingRepository stagingRepository);
 
 	<M extends ProjectAware> M triggerBuild(M module);
 

--- a/src/main/java/org/springframework/data/release/build/MavenBuildSystem.java
+++ b/src/main/java/org/springframework/data/release/build/MavenBuildSystem.java
@@ -387,6 +387,23 @@ class MavenBuildSystem implements BuildSystem {
 		logger.log(iteration, "✅ Smoke tests passed. Do not smoke 🚭. It's unhealthy.");
 	}
 
+	/**
+	 * Perform a {@literal nexus-staging:rc-release}.
+	 */
+	@Override
+	public void release(StagingRepository stagingRepository) {
+
+		Assert.notNull(stagingRepository, "StagingRepository must not be null");
+		Assert.isTrue(stagingRepository.isPresent(), "StagingRepository must be present");
+
+		CommandLine arguments = CommandLine.of(goal("nexus-staging:rc-release"), //
+				profile("central"), //
+				arg("stagingRepositoryId").withValue(stagingRepository.getId()))
+				.andIf(!ObjectUtils.isEmpty(properties.getSettingsXml()), () -> settingsXml(properties.getSettingsXml()));
+
+		mvn.execute(BUILD, arguments);
+	}
+
 	@Override
 	public <M extends ProjectAware> M triggerDocumentationBuild(M module) {
 

--- a/src/main/java/org/springframework/data/release/cli/ReleaseCommands.java
+++ b/src/main/java/org/springframework/data/release/cli/ReleaseCommands.java
@@ -46,6 +46,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 @CliComponent
 @RequiredArgsConstructor
@@ -146,6 +147,15 @@ class ReleaseCommands extends TimedCommand {
 
 		if (iteration.getIteration().isPublic()) {
 			build.close(iteration.getModule(Projects.BUILD), StagingRepository.of(stagingRepositoryId));
+		}
+	}
+
+	@CliCommand(value = "release repository")
+	public void repositoryRelease(@CliOption(key = "", mandatory = true) TrainIteration iteration,
+			@CliOption(key = "stagingRepositoryId", mandatory = true) String stagingRepositoryId) {
+
+		if (iteration.getIteration().isPublic()) {
+			build.release(iteration.getModule(Projects.BUILD), StagingRepository.of(stagingRepositoryId));
 		}
 	}
 


### PR DESCRIPTION
Introduce "nexus-stagin:rc-release" as a command for Maven central releases. Include it into the `release build` flow, after smoke tests are completed. If smoke tests fail, then this step won't be executed.