### PR TITLE
Add database dependencies for Relational

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.data.build</groupId>
 	<artifactId>spring-data-release-cli</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.BUILD-database-dependencies-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/springframework/data/release/infra/Dependencies.java
+++ b/src/main/java/org/springframework/data/release/infra/Dependencies.java
@@ -22,6 +22,7 @@ import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 public class Dependencies {
 
@@ -133,6 +134,21 @@ public class Dependencies {
 			"org.springframework.ldap:spring-ldap-core");
 
 	public static final Dependency MAVEN = Dependency.of("Maven Wrapper", "org.apache.maven:apache-maven");
+
+	public static final Dependency H2 = Dependency.of("H2 Database", "com.h2database:h2");
+	public static final Dependency H2_R2DBC = Dependency.of("H2 R2DBC Driver", "io.r2dbc:r2dbc-h2");
+	public static final Dependency HSQLDB = Dependency.of("HSQL Database", "org.hsqldb:hsqldb");
+	public static final Dependency DB2_JDBC = Dependency.of("DB2 JDBC Driver", "com.ibm.db2:jcc");
+	public static final Dependency MARIADB_JDBC = Dependency.of("MariaDB JDBC Driver", "org.mariadb.jdbc:mariadb-java-client");
+	public static final Dependency MARIADB_R2DBC = Dependency.of("MariaDB R2DBC Driver", "rg.mariadb:r2dbc-mariadb");
+	public static final Dependency MS_SQLSERVER_JDBC = Dependency.of("Microsoft SqlServer JDBC Driver", "com.microsoft.sqlserver:mssql-jdbc");
+	public static final Dependency MS_SQLSERVER_R2DBC = Dependency.of("Microsoft SqlServer R2DBC Driver", "io.r2dbc:r2dbc-mssql");
+	public static final Dependency MYSQL_JDBC = Dependency.of("MySql JDBC Driver", "mysql:mysql-connector-java");
+	public static final Dependency MYSQL_R2DBC = Dependency.of("MySql R2DBC Driver", "io.asyncer:r2dbc-mysql");
+	public static final Dependency POSTGRES_JDBC = Dependency.of("Postgres JDBC Driver", "org.postgresql:postgresql");
+	public static final Dependency POSTGRES_R2DBC = Dependency.of("Postgres R2DBC Driver", "org.postgresql:r2dbc-postgresql");
+	public static final Dependency ORACLE_JDBC = Dependency.of("Oracle JDBC Driver", "com.oracle.database.jdbc:ojdbc11");
+	public static final Dependency ORACLE_R2DBC = Dependency.of("Oracle R2DBC Driver", "com.oracle.database.r2dbc:oracle-r2dbc");
 
 	static {
 

--- a/src/main/java/org/springframework/data/release/infra/DependencyOperations.java
+++ b/src/main/java/org/springframework/data/release/infra/DependencyOperations.java
@@ -75,6 +75,7 @@ import org.xmlbeam.io.StreamInput;
  * Operations for dependency management.
  *
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 @Component
 @RequiredArgsConstructor
@@ -476,7 +477,8 @@ public class DependencyOperations {
 				Dependency dependency = projectDependency.getDependency();
 
 				if (!(project == Projects.MONGO_DB && projectDependency.getProperty().equals("mongo.reactivestreams")
-						|| project == Projects.NEO4J || project == Projects.BUILD || project == Projects.JPA)) {
+						|| project == Projects.NEO4J || project == Projects.BUILD || project == Projects.JPA
+						|| project == Projects.RELATIONAL)) {
 
 					if (it.getDependencyVersion(dependency.getArtifactId()) == null
 							&& it.getManagedDependency(dependency.getArtifactId()) == null) {

--- a/src/main/java/org/springframework/data/release/infra/ProjectDependencies.java
+++ b/src/main/java/org/springframework/data/release/infra/ProjectDependencies.java
@@ -31,6 +31,7 @@ import org.springframework.util.MultiValueMap;
  * Configuration of dependencies for a specific project.
  *
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 public class ProjectDependencies implements Streamable<ProjectDependencies.ProjectDependency> {
 
@@ -99,6 +100,22 @@ public class ProjectDependencies implements Streamable<ProjectDependencies.Proje
 				ProjectDependency.ofProperty("elasticsearch-java", Dependencies.ELASTICSEARCH_REST_CLIENT));
 
 		config.add(Projects.LDAP, ProjectDependency.ofProperty("spring-ldap", Dependencies.SPRING_LDAP));
+
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("h2.version", Dependencies.H2));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("hsqldb.version", Dependencies.HSQLDB));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("db2.version", Dependencies.DB2_JDBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("mariadb-java-client.version", Dependencies.MARIADB_JDBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("mssql.version", Dependencies.MS_SQLSERVER_JDBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("mysql-connector-java.version", Dependencies.MYSQL_JDBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("postgresql.version", Dependencies.POSTGRES_JDBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("oracle.version", Dependencies.ORACLE_JDBC));
+
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("r2dbc-postgresql.version", Dependencies.POSTGRES_R2DBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("r2dbc-h2.version", Dependencies.H2_R2DBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("r2dbc-mariadb.version", Dependencies.MARIADB_R2DBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("r2dbc-mssql.version", Dependencies.MS_SQLSERVER_R2DBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("r2dbc-mysql.version", Dependencies.MYSQL_R2DBC));
+		config.add(Projects.RELATIONAL, ProjectDependency.ofProperty("oracle-r2dbc.version", Dependencies.ORACLE_R2DBC));
 	}
 
 	private final List<ProjectDependency> dependencies;

--- a/src/main/java/org/springframework/data/release/model/Version.java
+++ b/src/main/java/org/springframework/data/release/model/Version.java
@@ -29,7 +29,7 @@ public class Version implements Comparable<Version> {
 	private Version(BigDecimal... parts) {
 
 		Assert.notNull(parts, "Parts must not be null!");
-		Assert.isTrue(parts.length > 0 && parts.length < 5, "We need at least 1 at most 4 parts!");
+		Assert.isTrue(parts.length > 0, "We need at least 1 part!");
 
 		this.major = parts[0];
 		this.minor = parts.length > 1 ? parts[1] : BigDecimal.ZERO;


### PR DESCRIPTION
Includes a change that removes a check for Versionsstrings with more then 4 numeric parts, which fails for Oracle versions.

See also: https://github.com/spring-projects/spring-data-relational/pull/1892