### PR TITLE
Fix commit message for Broadcom license header update

### DIFF
--- a/src/main/java/org/springframework/data/release/infra/LicenseHeaderCommands.java
+++ b/src/main/java/org/springframework/data/release/infra/LicenseHeaderCommands.java
@@ -106,7 +106,11 @@ public class LicenseHeaderCommands extends TimedCommand {
 			int updated = updateLicense(year, module);
 
 			if (updated > 0) {
-				commitAndPushWithTicket(module, String.format("Extend license header copyright years to %d", year));
+				String commitMsg = String.format("Extend license header copyright years to %s", year);
+				if (module.getSupportStatus() == SupportStatus.COMMERCIAL) {
+					commitMsg = commitMsg + " and replace Apache 2 with Broadcom license";
+				}
+				commitAndPushWithTicket(module, commitMsg);
 			}
 		});
 	}


### PR DESCRIPTION
This fixes an issue introduced in commit e0dbf5e4ba38cd0ef5f6a9f9cd1919eb32c6ce1d where the format string for the commit message now requires a string for the year parameter.

Also, the commit message is extended to mention the Broadcom license header update when the module is commercially supported.