### PR TITLE
Make sure to update GH Actions & Workflows after release.

### DIFF
--- a/src/test/java/org/springframework/data/release/build/MavenBuildSystemUnitTests.java
+++ b/src/test/java/org/springframework/data/release/build/MavenBuildSystemUnitTests.java
@@ -78,4 +78,26 @@ class MavenBuildSystemUnitTests {
 					"<enabled>true</enabled>", "<releases>", "<enabled>false</enabled>", "spring-milestone");
 		}
 	}
+
+	@Test
+	void ghActionsRegexShouldCaptureVesion() {
+
+		String workflow = """
+			- name: Setup Java and Maven
+			  uses: spring-projects/spring-data-build/actions/setup-maven@5.0.x
+			- name: Deploy to Artifactory
+			  uses: spring-projects/spring-data-build/actions/maven-artifactory-deploy@main
+			- uses: actions/setup-java@v5.2.0
+			  id: install-custom-java-version
+			""";
+
+		String newTag = "newTag";
+
+		String result = workflow.replaceAll(MavenBuildSystem.GH_ACTION_REGEX, "@" + newTag);
+
+		assertThat(result)
+			.contains("uses: spring-projects/spring-data-build/actions/setup-maven@newTag")
+			.contains("uses: spring-projects/spring-data-build/actions/maven-artifactory-deploy@newTag")
+			.contains("uses: actions/setup-java@v5.2.0");
+	}
 }


### PR DESCRIPTION
We need to make sure to update Github Action and Workflow files when switching from _main_ development line to a new branch. In doing so we make sure that changes on the _main_ line for the next development iteration do not necessarily effect the build of previous iterations.

To do so we pin:
- `uses` directives that point to spring-data-build actions to the maintenance branch.
- `on push branches` directives to only react on maintenance branch pushes.